### PR TITLE
Automate the generation of Top Ranking Issues

### DIFF
--- a/.github/workflows/update_top_ranking_issues.yml
+++ b/.github/workflows/update_top_ranking_issues.yml
@@ -1,0 +1,18 @@
+on:
+  issues:
+    types: [closed]
+  schedule:
+    - cron: "*/5 * * * *" # TODO: Change to a real schedule once everything works: 0 */12 * * *
+
+jobs:
+  update_top_ranking_issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10.5"
+          architecture: "x64"
+          cache: "pip"
+      - run: pip install -r scripts/update_top_ranking_issues/requirements.txt
+      - run: python scripts/update_top_ranking_issues/main.py ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/update_top_ranking_issues/main.py
+++ b/scripts/update_top_ranking_issues/main.py
@@ -1,6 +1,6 @@
+import sys
 from datetime import datetime
 
-from dotenv import dotenv_values
 from github import Github
 
 
@@ -16,7 +16,7 @@ class IssueData:
 
 
 def main():
-    github_access_token = dotenv_values(".env")["GITHUB_ACCESS_TOKEN"]
+    github_access_token = sys.argv[1]
     github = Github(github_access_token)
 
     repo_name = "zed-industries/feedback"

--- a/scripts/update_top_ranking_issues/requirements.txt
+++ b/scripts/update_top_ranking_issues/requirements.txt
@@ -1,2 +1,1 @@
 PyGithub==1.55
-python-dotenv==0.20.0


### PR DESCRIPTION
This PR automates the editing of the Top Ranking Issues issue (and subsequently frees me from the shackles of manually running that script on my local machine 🤣)

Its hard to tell if this will work right away - [I created a local repository and did my testing there](https://github.com/JosephTLyons/action_minutes_test) and [it works](https://github.com/JosephTLyons/action_minutes_test/issues/1), but bringing it into this repo required some tweaks (and this is my first time working with GitHub Actions).  The PR has it regenerating every 5 minutes, which is just meant for debugging purposes - once it works, I think dropping it down to every 12 hours would be fine.  I also have it triggered via issue closes, with the idea being that it could be a top-ranking issue that is closed, so we want to regenerate it.  If I could further tweak that to just listen to the closing of issues mentioned in the top-ranking issues issue, I would, but that isn't possible it seems.