### PR TITLE
Add documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/3_documentation_issue.yml
+++ b/.github/ISSUE_TEMPLATE/3_documentation_issue.yml
@@ -1,0 +1,18 @@
+name: Documentation Issue
+description: Report typos, questions about the documentation, or ask how two sections relate
+labels: ["documentation"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Check for existing issues
+      description: Check the backlog of issues to reduce the chances of creating duplicates; if an issue already exists, place a `+1` (👍) on it.
+  - type: input
+    attributes:
+      label: Page link
+      description: Where the documentation this issue is about can be found.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Description
+      description: What could be improved? How could the section be worded better or better understandable?

--- a/.github/ISSUE_TEMPLATE/3_documentation_issue.yml
+++ b/.github/ISSUE_TEMPLATE/3_documentation_issue.yml
@@ -1,6 +1,6 @@
 name: Documentation Issue
 description: Report typos, questions about the documentation, or ask how two sections relate
-labels: ["documentation"]
+labels: ["documentation", "triage"]
 body:
   - type: checkboxes
     attributes:


### PR DESCRIPTION
Since my issues #865 and #864 don't have any category label (and normal users outside of Zed are unable to add any), I thought it would be worth adding an issue template. This way documentation issues created with it automatically have the correct label.